### PR TITLE
22 make all problems publicly visible

### DIFF
--- a/src/main/java/com/olimpiici/arena/config/SecurityConfiguration.java
+++ b/src/main/java/com/olimpiici/arena/config/SecurityConfiguration.java
@@ -108,6 +108,7 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
             .antMatchers("/api/public/**").permitAll()
             .antMatchers("/api/competitions/**").permitAll()
             .antMatchers("/api/tags/**").permitAll()
+            .antMatchers("/api/problems/**").permitAll()
             .antMatchers("/api/**").authenticated()
             .antMatchers("/management/health").permitAll()
             .antMatchers("/management/info").permitAll()

--- a/src/main/java/com/olimpiici/arena/config/SecurityConfiguration.java
+++ b/src/main/java/com/olimpiici/arena/config/SecurityConfiguration.java
@@ -106,6 +106,7 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
             .antMatchers("/api/account/reset-password/init").permitAll()
             .antMatchers("/api/account/reset-password/finish").permitAll()
             .antMatchers("/api/public/**").permitAll()
+            .antMatchers("/api/competitions/**").permitAll()
             .antMatchers("/api/**").authenticated()
             .antMatchers("/management/health").permitAll()
             .antMatchers("/management/info").permitAll()

--- a/src/main/java/com/olimpiici/arena/config/SecurityConfiguration.java
+++ b/src/main/java/com/olimpiici/arena/config/SecurityConfiguration.java
@@ -107,6 +107,7 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
             .antMatchers("/api/account/reset-password/finish").permitAll()
             .antMatchers("/api/public/**").permitAll()
             .antMatchers("/api/competitions/**").permitAll()
+            .antMatchers("/api/tags/**").permitAll()
             .antMatchers("/api/**").authenticated()
             .antMatchers("/management/health").permitAll()
             .antMatchers("/management/info").permitAll()

--- a/src/main/java/com/olimpiici/arena/web/rest/CompetitionResource.java
+++ b/src/main/java/com/olimpiici/arena/web/rest/CompetitionResource.java
@@ -64,16 +64,16 @@ public class CompetitionResource {
     private static final String ENTITY_NAME = "competition";
 
     private final CompetitionService competitionService;
-    
+
     private final SubmissionService submissionService;
 
     private final UserRepository userRepository;
 
     private final ProblemService problemService;
-    
+
     @Autowired
     private ApplicationProperties applicationProperties;
-    
+
     public CompetitionResource(CompetitionService competitionService,
     		UserRepository userRepository,
     		SubmissionService submissionService,
@@ -106,25 +106,25 @@ public class CompetitionResource {
             .headers(HeaderUtil.createEntityCreationAlert(ENTITY_NAME, result.getId().toString()))
             .body(result);
     }
-    
+
     @PostMapping("/competitions/{id}/subcompetitions")
     @Timed
     @PreAuthorize("hasRole(\"" + AuthoritiesConstants.ADMIN + "\")")
     public ResponseEntity<CompetitionDTO> updateSubCompetitions(@PathVariable Long id,
     		@RequestBody List<CompetitionDTO> subCompetitions) throws URISyntaxException {
         log.debug("REST request to set cubcompetitions: {}", id);
-        
+
         competitionService.updateSubCompetitions(id, subCompetitions);;
         return ResponseEntity.ok().build();
     }
-    
+
     @PostMapping("/competitions/{id}/subproblems")
     @Timed
     @PreAuthorize("hasRole(\"" + AuthoritiesConstants.ADMIN + "\")")
     public ResponseEntity<CompetitionDTO> updateSubProblems(@PathVariable Long id,
     		@RequestBody List<CompetitionProblemDTO> subProblems) throws URISyntaxException {
         log.debug("REST request to set subproblems: {}", id);
-        
+
         competitionService.updateSubProblems(id, subProblems);
         return ResponseEntity.ok().build();
     }
@@ -181,7 +181,7 @@ public class CompetitionResource {
         Optional<CompetitionDTO> competitionDTO = competitionService.findOne(id);
         return ResponseUtil.wrapOrNotFound(competitionDTO);
     }
-    
+
     /**
      * GET  /competitions/:id/children : get the children of "id" competition.
      *
@@ -198,7 +198,7 @@ public class CompetitionResource {
         HttpHeaders headers = PaginationUtil.generatePaginationHttpHeaders(page, url);
         return ResponseEntity.ok().headers(headers).body(page.getContent());
     }
-    
+
     @GetMapping("/competitions/{id}/path")
     @Timed
     public ResponseEntity<List<CompetitionDTO>> getCompetitionPath(@PathVariable Long id) {
@@ -206,18 +206,18 @@ public class CompetitionResource {
         List<CompetitionDTO> path = competitionService.findPathFromRoot(id);
         return ResponseEntity.ok(path);
     }
-    
+
     @GetMapping("/competitions/{id}/submissions")
     @Timed
     public ResponseEntity<List<SubmissionDTO>> getCompetitionSubmissions(
     		@PathVariable Long id, Pageable pageable) {
         log.debug("REST request to get Competition submissoins : {}", id);
         Page<SubmissionDTO> page;
-        
+
         if (SecurityUtils.isCurrentUserInRole(AuthoritiesConstants.ADMIN)) {
         	page = competitionService.findSubmissionsByCompetition(id, pageable);
         } else {
-        	User user = 
+        	User user =
         			userRepository.findOneByLogin(SecurityUtils.getCurrentUserLogin().get()).get();
         	page = competitionService.findSubmissionsByCompetitionAndUser(user, id, pageable);
         }
@@ -225,20 +225,20 @@ public class CompetitionResource {
         HttpHeaders headers = PaginationUtil.generatePaginationHttpHeaders(page, url);
         return ResponseEntity.ok().headers(headers).body(page.getContent());
     }
-    
+
     @GetMapping("/competitions/{id}/problems")
     @Timed
     public ResponseEntity<List<CompetitionProblemDTO>> getCompetitionProblems(
     		@PathVariable Long id, Pageable pageable, Principal principal) {
         log.debug("REST request to get Competition problems : {}", id);
-        
+
         User user = userRepository
         		.findOneByLogin(SecurityUtils.getCurrentUserLogin().get())
         		.get();
-        
+
         Page<CompetitionProblemDTO> page = competitionService.findProblems(id, pageable);
         for (CompetitionProblemDTO dto : page.getContent()) {
-        	
+
         	Integer points = competitionService.findPointsForCompetitionProblem(user, dto.getId());
         	dto.setPoints(points);
         }
@@ -246,7 +246,7 @@ public class CompetitionResource {
         HttpHeaders headers = PaginationUtil.generatePaginationHttpHeaders(page, url);
         return ResponseEntity.ok().headers(headers).body(page.getContent());
     }
-    
+
     @GetMapping("/competitions/{id}/problem/{compProb}")
     @Timed
     public ResponseEntity<ProblemDTO> getCompetitionProblem(
@@ -256,11 +256,12 @@ public class CompetitionResource {
         problemService.setLimitsToDto(problem);
         return ResponseEntity.ok(problem);
     }
-    
+
     @PostMapping("/competitions/{id}/problem/{compProb}/submit")
+    @PreAuthorize("hasRole(\"" + AuthoritiesConstants.USER + "\")")
     @Timed
-    public ResponseEntity<SubmissionDTO> submitProblem(@PathVariable Long id, 
-    		@PathVariable Long compProb, 
+    public ResponseEntity<SubmissionDTO> submitProblem(@PathVariable Long id,
+    		@PathVariable Long compProb,
     		@RequestBody String solution) throws Exception {
         log.debug("REST request to submit solution : {}", solution);
 
@@ -279,27 +280,27 @@ public class CompetitionResource {
 	        File submissionsDir = new File(applicationProperties.getWorkDir(), "submissions");
 	        File submissionDir = new File(submissionsDir, ""+submission.getId());
 	        File submissionFile = new File(submissionDir, "solution.cpp");
-	        
+
 	        submissionDir.mkdirs();
 	        FileUtils.writeStringToFile(submissionFile, solution, StandardCharsets.UTF_8);
 	        submission.setVerdict("waiting");
         }
 
         submissionService.save(submission);
-        
+
         return ResponseEntity.ok(submission);
     }
-    
+
     @GetMapping("/competitions/{id}/problem/{compProb}/submissions")
     @Timed
-    public ResponseEntity<List<SubmissionDTO>> getSubmissions(@PathVariable Long id, 
+    public ResponseEntity<List<SubmissionDTO>> getSubmissions(@PathVariable Long id,
     		@PathVariable Long compProb, Pageable pageable) {
         log.debug("REST request to get submission for competitive problem : {}", compProb);
         Page<SubmissionDTO> page;
         if (SecurityUtils.isCurrentUserInRole(AuthoritiesConstants.ADMIN)) {
         	page = submissionService.findSubmissionsByCompetitionProblem(compProb, pageable);
         } else {
-        	User user = 
+        	User user =
         			userRepository.findOneByLogin(SecurityUtils.getCurrentUserLogin().get()).get();
         	page = submissionService.findSubmissionsByCompetitionProblemAndUser(user, compProb, pageable);
         }
@@ -307,7 +308,7 @@ public class CompetitionResource {
         HttpHeaders headers = PaginationUtil.generatePaginationHttpHeaders(page, url);
         return ResponseEntity.ok().headers(headers).body(page.getContent());
     }
-    
+
     @GetMapping("/competitions/{id}/standings")
     @Timed
     public ResponseEntity<List<UserPoints>> getStandings(@PathVariable Long id, Pageable pageable) {
@@ -317,7 +318,7 @@ public class CompetitionResource {
         HttpHeaders headers = PaginationUtil.generatePaginationHttpHeaders(page, url);
         return ResponseEntity.ok().headers(headers).body(page.getContent());
     }
-    
+
     /**
      * DELETE  /competitions/:id : delete the "id" competition.
      *

--- a/src/main/webapp/app/entities/competition/competition.route.ts
+++ b/src/main/webapp/app/entities/competition/competition.route.ts
@@ -42,7 +42,7 @@ export const competitionRoute: Routes = [
             pagingParams: JhiResolvePagingParams
         },
         data: {
-            authorities: ['ROLE_USER'],
+            authorities: ['ROLE_ADMIN'],
             defaultSort: 'id,asc',
             pageTitle: 'arenaApp.competition.home.title'
         },

--- a/src/main/webapp/app/entities/competition/competition.route.ts
+++ b/src/main/webapp/app/entities/competition/competition.route.ts
@@ -61,7 +61,7 @@ export const competitionRoute: Routes = [
             parentCompetition: CompetitionResolve
         },
         data: {
-            authorities: ['ROLE_USER'],
+            authorities: [],
             defaultSort: 'id,asc',
             pageTitle: 'arenaApp.competition.home.title'
         },
@@ -75,7 +75,7 @@ export const competitionRoute: Routes = [
             pagingParams: JhiResolvePagingParams
         },
         data: {
-            authorities: ['ROLE_USER'],
+            authorities: [],
             defaultSort: 'id,desc',
             pageTitle: 'arenaApp.submission.home.title',
             forCompetition: true
@@ -89,7 +89,7 @@ export const competitionRoute: Routes = [
             competition: CompetitionResolve
         },
         data: {
-            authorities: ['ROLE_USER']
+            authorities: []
         },
         canActivate: [UserRouteAccessService]
     },
@@ -100,7 +100,7 @@ export const competitionRoute: Routes = [
             pagingParams: JhiResolvePagingParams
         },
         data: {
-            authorities: ['ROLE_USER'],
+            authorities: [],
             defaultSort: 'id,desc',
             pageTitle: 'arenaApp.submission.home.title',
             forProblem: true
@@ -114,7 +114,7 @@ export const competitionRoute: Routes = [
             competition: CompetitionResolve
         },
         data: {
-            authorities: ['ROLE_USER'],
+            authorities: [],
             pageTitle: 'arenaApp.competition.home.title'
         },
         canActivate: [UserRouteAccessService]
@@ -156,7 +156,7 @@ export const competitionRoute: Routes = [
             pagingParams: JhiResolvePagingParams
         },
         data: {
-            authorities: ['ROLE_USER'],
+            authorities: [],
             pageTitle: 'arenaApp.standings.title'
         },
         canActivate: [UserRouteAccessService]

--- a/src/main/webapp/app/entities/competition/problem-in-competition.component.html
+++ b/src/main/webapp/app/entities/competition/problem-in-competition.component.html
@@ -103,7 +103,7 @@
                 </dd>
             </dl>
 
-            <form *ngIf="problem.version > 0"
+            <form *ngIf="problem.version > 0 && currentAccount !== null"
                   name="submitSolutionForm" role="form" novalidate
                   (ngSubmit)="submit()" #submitSolutionForm="ngForm" >
                 <div>

--- a/src/main/webapp/app/entities/competition/problem-in-competition.component.ts
+++ b/src/main/webapp/app/entities/competition/problem-in-competition.component.ts
@@ -12,6 +12,7 @@ import { TagService } from '../tag';
 import { ProblemService } from '../problem';
 import { ITag } from '../../shared/model/tag.model';
 import { CompetitionProblemService } from '../competition-problem';
+import { AccountService } from '../../core';
 
 @Component({
     selector: 'jhi-problem-in-competition',
@@ -19,6 +20,7 @@ import { CompetitionProblemService } from '../competition-problem';
 })
 export class ProblemInCompetitionComponent implements OnInit {
     problem: IProblem;
+    currentAccount: any;
     competitionId: number;
     competitionProblemId: number;
     isSubmitting: boolean;
@@ -33,6 +35,7 @@ export class ProblemInCompetitionComponent implements OnInit {
         protected activatedRoute: ActivatedRoute,
         protected competitionService: CompetitionService,
         protected jhiAlertService: JhiAlertService,
+        protected accountService: AccountService,
         protected tagService: TagService,
         protected problemService: ProblemService,
         private titleService: Title,
@@ -52,6 +55,10 @@ export class ProblemInCompetitionComponent implements OnInit {
             },
             (res: HttpErrorResponse) => this.onError(res.message)
         );
+
+        this.accountService.identity().then(account => {
+            this.currentAccount = account;
+        });
 
         this.tagService
             .query(true)
@@ -76,7 +83,7 @@ export class ProblemInCompetitionComponent implements OnInit {
         this.competitionService.submitSolution(this.competitionId, this.competitionProblemId, this.solution).subscribe(
             (res: HttpResponse<ISubmission>) => {
                 this.isSubmitting = false;
-                let submission = res.body;
+                const submission = res.body;
                 this.router.navigate(['submission', submission.id, 'view'], {
                     queryParams: { securityKey: submission.securityKey }
                 });

--- a/src/main/webapp/app/entities/tag/tag.route.ts
+++ b/src/main/webapp/app/entities/tag/tag.route.ts
@@ -33,7 +33,7 @@ export const tagRoute: Routes = [
         path: 'tag',
         component: TagComponent,
         data: {
-            authorities: ['ROLE_USER'],
+            authorities: [],
             pageTitle: 'arenaApp.tag.home.title'
         },
         canActivate: [UserRouteAccessService]
@@ -45,7 +45,7 @@ export const tagRoute: Routes = [
             tag: TagResolve
         },
         data: {
-            authorities: ['ROLE_USER'],
+            authorities: [],
             pageTitle: 'arenaApp.tag.home.title'
         },
         canActivate: [UserRouteAccessService]
@@ -57,7 +57,7 @@ export const tagRoute: Routes = [
             tag: TagResolve
         },
         data: {
-            authorities: ['ROLE_USER'],
+            authorities: ['ROLE_ADMIN'],
             pageTitle: 'arenaApp.tag.home.title'
         },
         canActivate: [UserRouteAccessService]
@@ -69,7 +69,7 @@ export const tagRoute: Routes = [
             tag: TagResolve
         },
         data: {
-            authorities: ['ROLE_USER'],
+            authorities: ['ROLE_ADMIN'],
             pageTitle: 'arenaApp.tag.home.title'
         },
         canActivate: [UserRouteAccessService]


### PR DESCRIPTION
Такаа.

1. В `SecurityConfiguration.java` съм направил няколко базови ендпойнта да са публик. На практика не съм гледал дали самите ендпойнти вътре се регулират правилно, но досега не съм виждал мизерии. 
2. `/competitions/` е по-скоро админски, но е е нужен да се дисплейнат задачите понеже иска `/competitions/1` . `/tags/` май е нужен да се дисплейват неща правилно. Като цяло гледах кои заявки гърмят като се отвори задачката
3. `@PreAuthorize("hasRole(\"" + AuthoritiesConstants.USER + "\")")` Липсваше на заявката за събмитване на решение и джавата пак се опитваше да прави нов фолдър дори когато не бях логнат. Очаквам си баунтито по пейпал.
4. Прегледай ангулар правата които съм ръчкал. Понеже `/competition/` е админска страница и не може да се достъпи освен през админ панела съм го направил админ. Или да се добави евентуално таб 'Съзтезания'? 
5. Същото за `/tag/new` и `/tag/:id/edit`.
6. За страницата със събмита просто съм скрил събмит формата ако юзъра няма акаунт. Не знам дали е правилен ангулар, дай съвети.